### PR TITLE
Permit version, body and keywords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,10 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
 Layout/LineLength:
-  Enabled: 111 # TODO: discuss and set this
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
 
 Rails:
   Enabled: true
@@ -39,6 +42,9 @@ Metrics/BlockLength:
   Enabled: false
 
 Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/IfUnlessModifier:
   Enabled: false
 
 Metrics/ClassLength:

--- a/app/controllers/api/v2/host_reports_controller.rb
+++ b/app/controllers/api/v2/host_reports_controller.rb
@@ -45,9 +45,15 @@ module Api
       param_group :host_report, as: :create
 
       def create
-        @host_report = HostReport.new(host_report_params)
-        if params[:host_report][:keywords].present?
-          keywords = params[:host_report][:keywords].each_with_object([]) do |n, ks|
+        the_body = params[:host_report].delete(:body)
+        if the_body && !the_body.is_a?(String)
+          logger.warn "Report body not as a string, serializing JSON"
+          the_body = JSON.pretty_generate(the_body)
+        end
+        keywords = params[:host_report].delete(:keywords)
+        @host_report = HostReport.new(host_report_params.merge(body: the_body))
+        if keywords.present?
+          keywords = keywords.each_with_object([]) do |n, ks|
             ks << { name: n }
           end
           @host_report.report_keyword_ids = ReportKeyword.upsert_all(

--- a/app/controllers/concerns/foreman_host_reports/controller/parameters/host_report.rb
+++ b/app/controllers/concerns/foreman_host_reports/controller/parameters/host_report.rb
@@ -9,8 +9,9 @@ module ForemanHostReports
         class_methods do
           def host_report_params_filter
             Foreman::ParameterFilter.new(::HostReport).tap do |filter|
-              filter.permit :host, :proxy, :reported_at, :format, :status,
-                :body, :proxy_id, :host_id
+              # body is permitted in controller
+              filter.permit :format, :version, :host, :proxy, :reported_at, :status, :proxy_id, :host_id
+              filter.permit :keywords => []
             end
           end
         end

--- a/app/models/host_report.rb
+++ b/app/models/host_report.rb
@@ -11,7 +11,7 @@ class HostReport < ApplicationRecord
   has_one :organization, through: :host
   has_one :location, through: :host
 
-  validates :host_id, :reported_at, :status, :body, presence: true
+  validates :host_id, :reported_at, :status, presence: true
 
   enum format: {
     # plain text report (no processing)


### PR DESCRIPTION
Sending report with body and keywords did not work for me, this patch fixes it plus it allows also sending as plain JSON - this will not be used for production but it is useful for testing.

To test, create a `localhost` smart proxy and `report.example.com` host and in the smart proxy plugin repo do:

```
curl -H "Accept:application/json,version=2" -H "Content-Type:application/json" -X POST -d @test/snapshots/foreman-web.json http://localhost:5000/api/v2/host_reports
```