### PR TITLE
Use version and cleanup response

### DIFF
--- a/app/controllers/api/v2/host_reports_controller.rb
+++ b/app/controllers/api/v2/host_reports_controller.rb
@@ -45,6 +45,7 @@ module Api
       param_group :host_report, as: :create
 
       def create
+        params[:host_report].delete(:version)
         the_body = params[:host_report].delete(:body)
         if the_body && !the_body.is_a?(String)
           logger.warn "Report body not as a string, serializing JSON"
@@ -60,7 +61,9 @@ module Api
             keywords, unique_by: :name
           ).rows.flatten
         end
-        process_response @host_report.save
+        result = @host_report.save
+        @host_report.body = nil
+        process_response result
       end
 
       api :DELETE, '/host_reports/:id', N_('Delete a host report')


### PR DESCRIPTION
Version must be removed before AR object is created, no need to store it until we have at least one version 2 which might not even happen.

Response contains full body which is too big and it logs into Rails log, so let's unset it.