### PR TITLE
Add support for global/config host status

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Layout/EmptyLineAfterGuardClause:
 Layout/LineLength:
   Enabled: false
 
-Metrics/MethodLength:
+Metrics:
   Enabled: false
 
 Rails:

--- a/app/controllers/concerns/foreman_host_reports/controller/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_host_reports/controller/hosts_controller_extensions.rb
@@ -1,0 +1,18 @@
+module ForemanHostReports
+  module Controller
+    module HostsControllerExtensions
+      extend ActiveSupport::Concern
+
+      module Overrides
+        def preload_reports
+          @last_report_ids = HostReport.where(:host_id => @hosts.map(&:id)).reorder('').group(:host_id).maximum(:id)
+          @last_reports = HostReport.where(:id => @last_report_ids.values)
+        end
+      end
+
+      included do
+        prepend Overrides
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_host_reports/host_extensions.rb
+++ b/app/models/concerns/foreman_host_reports/host_extensions.rb
@@ -4,6 +4,12 @@ module ForemanHostReports
 
     included do
       has_many :host_reports, foreign_key: :host_id, class_name: 'HostReport', inverse_of: :host, dependent: :destroy
+      has_one :last_host_report_object_any_format, -> { order("#{HostReport.table_name}.reported_at DESC, #{HostReport.table_name}.id").limit(1) }, foreign_key: :host_id, class_name: 'HostReport', inverse_of: :host, dependent: :delete
+      has_one :host_report_status_object, class_name: 'HostStatus::HostReportStatus', foreign_key: :host_id, inverse_of: :host, dependent: :delete
+
+      scoped_search relation: :host_reports, on: :change, rename: :report_changes, only_explicit: true
+      scoped_search relation: :host_reports, on: :nochange, rename: :report_nochanges, only_explicit: true
+      scoped_search relation: :host_reports, on: :failure, rename: :report_failures, only_explicit: true
     end
   end
 end

--- a/app/models/host_report.rb
+++ b/app/models/host_report.rb
@@ -24,9 +24,9 @@ class HostReport < ApplicationRecord
   scoped_search relation: :proxy, on: :name, complete_value: true, rename: :proxy
   scoped_search relation: :organization, on: :name, complete_value: true, rename: :organization
   scoped_search relation: :location, on: :name, complete_value: true, rename: :location
-  scoped_search on: :change, aliases: %i[changed]
-  scoped_search on: :nochange, aliases: %i[unchanged]
-  scoped_search on: :failure, aliases: %i[failed]
+  scoped_search on: :change, aliases: %i[changed changes]
+  scoped_search on: :nochange, aliases: %i[unchanged nochanges]
+  scoped_search on: :failure, aliases: %i[failed failures]
   scoped_search on: :reported_at, complete_value: true, default_order: :desc, rename: :reported, only_explicit: true, aliases: %i[last_report reported_at]
   scoped_search on: :format, complete_value: { plain: 0, puppet: 1, ansible: 2 }
   # This is to simulate has_many :report_keywords relation for scoped_search library to work

--- a/app/models/host_status/host_report_status.rb
+++ b/app/models/host_status/host_report_status.rb
@@ -1,0 +1,185 @@
+module HostStatus
+  # rubocop:disable Style/GuardClause
+  class HostReportStatus < Status
+    def last_report
+      self.last_report = host.last_host_report_object_any_format unless @last_report_set
+      @last_report
+    end
+
+    def last_report=(report)
+      @last_report_set = true
+      @last_report = report
+    end
+
+    # <host report fields>
+    def change
+      last_report&.change || 0
+    end
+
+    def nochange
+      last_report&.nochange || 0
+    end
+
+    def failure
+      last_report&.failure || 0
+    end
+
+    def change?
+      change.positive?
+    end
+
+    def nochange?
+      nochange.positive?
+    end
+
+    def failure?
+      failure.positive?
+    end
+    # </host report fields>
+
+    # <legacy report compatibility fields>
+    def restarted
+      0
+    end
+
+    def failed_restarts
+      0
+    end
+
+    def skipped
+      0
+    end
+    # </legacy report compatibility fields>
+
+    def expected_report_interval
+      (reported_format_interval.presence || default_report_interval).to_i.minutes
+    end
+
+    def reported_format_interval
+      if host.params.key? "#{last_report.format.downcase}_interval"
+        host.params["#{last_report.format.downcase}_interval"]
+      else
+        Setting[:"#{last_report.format.downcase}_interval"]
+      end
+    end
+
+    def out_of_sync?
+      if (host && !host.enabled?) || no_reports? || out_of_sync_disabled?
+        false
+      else
+        !reported_at.nil? && reported_at < (Time.now.utc - expected_report_interval)
+      end
+    end
+
+    def no_reports?
+      host && last_report.nil?
+    end
+
+    def self.status_name
+      N_("Configuration")
+    end
+
+    # Constants are bit-mask friendly in case we want to query them in the DB
+    UNKNOWN     = -0b000000000000010000000000000000 # -65536
+    FAILURES    = -0b000000000000000000000000000001 # -1
+    EMPTY       =  0b000000000000000000000000000000 # 0
+    NO_CHANGES  =  0b000000000000000000000100000000 # 256
+    CHANGES     =  0b000000000000010000000000000000 # 65536
+
+    LABELS = {
+      FAILURES => N_("Failure(s)"),
+      EMPTY => N_("Empty"),
+      NO_CHANGES => N_("No changes"),
+      CHANGES => N_("Changes applied"),
+    }.freeze
+
+    def to_label(_options = {})
+      if host && !host.enabled
+        return N_("Alerts disabled")
+      elsif out_of_sync?
+        return N_("Out of sync")
+      end
+
+      LABELS.fetch(to_status, N_("Unknown config status"))
+    end
+
+    def to_global(options = {})
+      handle_options(options)
+
+      if failure?
+        HostStatus::Global::ERROR
+      elsif out_of_sync?
+        HostStatus::Global::WARN
+      elsif no_reports? && (host.configuration? || Setting[:always_show_configuration_status])
+        HostStatus::Global::WARN
+      else
+        HostStatus::Global::OK
+      end
+    end
+
+    def to_status(options = {})
+      handle_options(options)
+
+      if host&.enabled && last_report.present?
+        if last_report.failure.positive?
+          FAILURES
+        elsif last_report.change.positive?
+          CHANGES
+        elsif last_report.nochange.positive?
+          NO_CHANGES
+        else
+          EMPTY
+        end
+      else
+        UNKNOWN
+      end
+    end
+
+    def relevant?(options = {})
+      handle_options(options)
+
+      host.configuration? || last_report.present? || Setting[:always_show_configuration_status]
+    end
+
+    def status_link
+      return @status_link if defined?(@status_link)
+      return @status_link = nil if last_report.nil?
+      return @status_link = nil unless User.current.can?(:view_host_reports, last_report, false)
+
+      @status_link = last_report && Rails.application.routes.url_helpers.host_report_path(last_report)
+    end
+
+    private
+
+    # Configuration status can be calculated from database state, but also reports can be
+    # passed in via options. In that case, report is matched with the host and set.
+    # Don't ask me why this is implemented this way, this is copy-paste from the original
+    # ConfigurationStatus in Foreman core.
+    def handle_options(options)
+      if options.key?(:last_reports) && !options[:last_reports].nil?
+        cached_report = options[:last_reports].find { |r| r.host_id == host_id }
+        self.last_report = cached_report
+      end
+    end
+
+    def update_timestamp
+      self.reported_at = last_report.try(:reported_at) || Time.now.utc
+    end
+
+    def default_report_interval
+      if host.params.key? 'outofsync_interval'
+        host.params['outofsync_interval']
+      else
+        Setting[:outofsync_interval]
+      end
+    end
+
+    def out_of_sync_disabled?
+      Setting[:"#{last_report.format.downcase}_out_of_sync_disabled"]
+    end
+  end
+  # rubocop:enable Style/GuardClause
+end
+
+HostStatus.status_registry.delete(HostStatus::ConfigurationStatus)
+HostStatus.status_registry.add(HostStatus::HostReportStatus)

--- a/lib/foreman_host_reports/engine.rb
+++ b/lib/foreman_host_reports/engine.rb
@@ -40,6 +40,10 @@ module ForemanHostReports
           caption: N_('Host Reports'),
           parent: :monitor_menu,
           before: :reports
+
+        add_histogram_telemetry(:host_report_create_keywords, 'Time spent processing keywords (ms)')
+        add_histogram_telemetry(:host_report_create_refresh, 'Time spent processing status refresh (ms)')
+        add_histogram_telemetry(:host_report_create, 'Time spent saving record (ms)')
       end
     end
 
@@ -48,6 +52,7 @@ module ForemanHostReports
     config.to_prepare do
       Host::Managed.include ForemanHostReports::HostExtensions
       SmartProxy.include ForemanHostReports::HostExtensions
+      ::HostsController.include ForemanHostReports::Controller::HostsControllerExtensions
     rescue => e
       Rails.logger.warn "ForemanHostReports: skipping engine hook (#{e})"
     end

--- a/test/factories/foreman_host_reports_factories.rb
+++ b/test/factories/foreman_host_reports_factories.rb
@@ -1,11 +1,20 @@
 FactoryBot.define do
   factory :host_report do
     host
+    sequence(:proxy) { |n| FactoryBot.create(:smart_proxy, url: "http://proxy#{n}.example.com", features: [FactoryBot.create(:feature, name: 'Reports')]) }
     reported_at { Time.now.utc }
     change { 0 }
     nochange { 0 }
     failure { 0 }
-    body { 'report data' }
+    body { '{}' }
+  end
+
+  trait :puppet_format do
+    format { 'puppet' }
+  end
+
+  trait :ansible_format do
+    format { 'ansible' }
   end
 
   trait :with_keyword do

--- a/test/model/host_report_status_test.rb
+++ b/test/model/host_report_status_test.rb
@@ -1,0 +1,204 @@
+require 'test_helper'
+
+class HostReportStatusTest < ActiveSupport::TestCase
+  let(:report) { FactoryBot.create(:host_report) }
+  let(:host) { report.host }
+  let(:status) { HostStatus::HostReportStatus.new(host: host).tap(&:refresh) }
+
+  test 'is valid' do
+    assert_valid status
+  end
+
+  test 'last_report defaults to hosts last if nothing was set yet' do
+    assert_equal report, status.last_report
+  end
+
+  test '#last_report returns custom value that was set using writer method' do
+    status.last_report = :something
+    assert_equal :something, status.last_report
+  end
+
+  test '#last_report returns custom value that was set using writer method even for nil' do
+    status.last_report = nil
+    assert_nil status.last_report
+  end
+
+  describe "host with no reports" do
+    let(:host) { FactoryBot.create(:host) }
+
+    test '#no_reports? results in warning only if puppet reports are expected' do
+      refute host.last_report
+
+      status.stubs(:error? => false)
+      status.stubs(:out_of_sync? => false)
+      status.stubs(:no_reports? => true)
+      assert_equal HostStatus::Global::OK, status.to_global
+
+      host.expects(:configuration? => true)
+      assert_equal HostStatus::Global::WARN, status.to_global
+
+      host.expects(:configuration? => false)
+      Setting[:always_show_configuration_status] = true
+      assert_equal HostStatus::Global::WARN, status.to_global
+    end
+  end
+
+  test 'status is disabled when reporting is disabled' do
+    host.enabled = false
+    assert_equal HostStatus::HostReportStatus::UNKNOWN, status.refresh
+  end
+
+  test '#out_of_sync? is false when reported_at is unknown' do
+    status.reported_at = nil
+    refute status.out_of_sync?
+  end
+
+  test '#out_of_sync? is false when window is big enough' do
+    original = Setting[:outofsync_interval]
+    Setting[:outofsync_interval] = (Time.now.utc - report.reported_at).to_i / 60 + 1
+    refute status.out_of_sync?
+    Setting[:outofsync_interval] = original
+  end
+
+  describe '#out_of_sync?' do
+    let(:report) { FactoryBot.create(:host_report, reported_at: Time.now.utc - 1.year) }
+
+    test '#out_of_sync? is false when out of sync is disabled' do
+      status.stubs(:out_of_sync_disabled?).returns(true)
+      refute status.out_of_sync?
+    end
+
+    context 'with last report format' do
+      setup do
+        status.last_report.stubs(:format).returns('Test')
+      end
+
+      test 'is false when formats out of sync is disabled' do
+        stub_outofsync_setting(true)
+        refute status.out_of_sync?
+      end
+
+      test "is true when formats out of sync isn't disbled and it is ouf of sync" do
+        stub_outofsync_setting(false)
+        status.reported_at = '2015-01-01 00:00:00'
+        status.save
+        assert status.out_of_sync?
+      end
+
+      def stub_outofsync_setting(value)
+        Foreman.settings._add('test_out_of_sync_disabled',
+          context: :test,
+          type: :boolean,
+          category: 'Setting',
+          full_name: 'Test out of sync',
+          description: 'description',
+          default: false)
+        Setting[:test_out_of_sync_disabled] = value
+      end
+    end
+  end
+
+  test '#refresh! refreshes the date and persists the record' do
+    status.expects(:refresh)
+    status.refresh!
+
+    assert status.persisted?
+  end
+
+  test '#refresh updates date to reported_at of last report' do
+    status.reported_at = nil
+    status.refresh
+
+    assert_equal report&.reported_at&.to_i, status&.reported_at&.to_i
+  end
+
+  test '#relevant? only for hosts with #configuration? true, or a last report, or setting enabled' do
+    host.expects(:configuration?).returns(true)
+    assert status.relevant?
+
+    host.expects(:configuration?).returns(false)
+    status.expects(:last_report).returns(mock)
+    assert status.relevant?
+
+    host.expects(:configuration?).returns(false)
+    status.expects(:last_report).returns(nil)
+    refute status.relevant?
+
+    host.expects(:configuration?).returns(false)
+    status.expects(:last_report).returns(nil)
+    Setting[:always_show_configuration_status] = true
+    assert status.relevant?
+  end
+
+  describe "host with puppet report" do
+    let(:report) { FactoryBot.create(:host_report, :puppet_format) }
+
+    test 'overwrite puppet_interval as host parameter' do
+      if defined? ForemanPuppet
+        Setting['puppet_interval'] = 25
+      end
+      Setting['outofsync_interval'] = 25
+      status.reported_at = Time.now.utc - 30.minutes
+      assert status.out_of_sync?
+      host.params['puppet_interval'] = 35
+      refute status.out_of_sync?
+    end
+  end
+
+  describe "host with applied changes" do
+    let(:report) { FactoryBot.create(:host_report, nochange: 0, change: 10, failure: 0) }
+
+    test 'is found via host scoped search' do
+      status.save
+      assert_equal [host], Host.search_for('report_changes > 0')
+      assert_empty Host.search_for('report_changes < 0')
+      assert_empty Host.search_for('report_changes = 0')
+    end
+
+    test 'is found via host report scoped search' do
+      status.save
+      assert_equal [report], HostReport.search_for('changes > 0')
+      assert_equal [report], HostReport.search_for('changed > 0')
+      assert_empty HostReport.search_for('changes < 0')
+      assert_empty HostReport.search_for('changed = 0')
+    end
+  end
+
+  describe "host with failures" do
+    let(:report) { FactoryBot.create(:host_report, nochange: 0, change: 0, failure: 10) }
+
+    test 'is found via host scoped search' do
+      status.save
+      assert_equal [host], Host.search_for('report_failures > 0')
+      assert_empty Host.search_for('report_failures < 0')
+      assert_empty Host.search_for('report_failures = 0')
+    end
+
+    test 'is found via host report scoped search' do
+      status.save
+      assert_equal [report], HostReport.search_for('failures > 0')
+      assert_equal [report], HostReport.search_for('failed > 0')
+      assert_empty HostReport.search_for('failures < 0')
+      assert_empty HostReport.search_for('failed = 0')
+    end
+  end
+
+  describe "host with no changes" do
+    let(:report) { FactoryBot.create(:host_report, nochange: 10, change: 0, failure: 0) }
+
+    test 'is found via host scoped search' do
+      status.save
+      assert_equal [host], Host.search_for('report_nochanges > 0')
+      assert_empty Host.search_for('report_nochanges < 0')
+      assert_empty Host.search_for('report_nochanges = 0')
+    end
+
+    test 'is found via host report scoped search' do
+      status.save
+      assert_equal [report], HostReport.search_for('unchanged > 0')
+      assert_equal [report], HostReport.search_for('nochanges > 0')
+      assert_empty HostReport.search_for('unchanged < 0')
+      assert_empty HostReport.search_for('nochanges = 0')
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -5,7 +5,9 @@ require 'test_helper'
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload
 
-def read_report(file)
+def read_report(file, override_proxy = "localhost")
   json = File.expand_path(File.join('..', 'snapshots', file), __FILE__)
-  File.read(json)
+  json = JSON.parse(File.read(json))
+  json["proxy"] = override_proxy
+  json.to_s
 end


### PR DESCRIPTION
The goal is to add new host status next to Configuration Status that would work similarly. What should work:

* status class registered
* status tests
* searching for hosts via status
* status refreshing on new report

The approach I take is that the plugin overrides ConfigurationStatus class with its own implementation. Everything else should stay as-is. Apparently, since Host Reports only store three fields (change, nochange, failure) status can only show that. It maps nicely to the global status (OK, WARN, ERR), changes are considered OK not WARN tho.

Testing:

Make sure to pull the latest smart proxy plugin which contains a patch to correctly handle reported_at flag. Use the upload-fixtures script to upload various report types (with errors, without errors, with changes etc) to test this patch.

This is now ready for review and testing!

There is one more thing - I have found a bug in the code - we associate proxies against names but smart proxy reports hostnames. Since we only store URL and proxy name in Foreman DB, it needs to be fixed in core (which I am going to do now): https://projects.theforeman.org/issues/34304