### PR TITLE
Ensure last_report is proper type in status

### DIFF
--- a/app/helpers/concerns/foreman_host_reports/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_host_reports/hosts_helper_extensions.rb
@@ -9,7 +9,7 @@ module ForemanHostReports
         time = record.last_report? ? date_time_relative_value(record.last_report) : ""
         if @last_report_ids[record.id]
           opts["data-original-title"] = date + _("view last report details")
-          link_to_if_authorized(time, hash_for_host_report_path(:id => record.last_host_report_object_any_format&.id), opts)
+          link_to_if_authorized(time, hash_for_host_report_path(:id => record.last_host_report_object&.id), opts)
         else
           opts.merge!(:disabled => true, :class => "disabled", :onclick => 'return false')
           opts["data-original-title"] = date + _("report already deleted") unless record.last_report.nil?

--- a/app/models/concerns/foreman_host_reports/host_extensions.rb
+++ b/app/models/concerns/foreman_host_reports/host_extensions.rb
@@ -4,13 +4,24 @@ module ForemanHostReports
 
     included do
       has_many :host_reports, foreign_key: :host_id, class_name: 'HostReport', inverse_of: :host, dependent: :destroy
-      has_one :last_host_report_object_any_format, -> { order("#{HostReport.table_name}.reported_at DESC, #{HostReport.table_name}.id").limit(1) }, foreign_key: :host_id, class_name: 'HostReport', inverse_of: :host, dependent: :delete
       has_one :host_report_status_object, class_name: 'HostStatus::HostReportStatus', foreign_key: :host_id, inverse_of: :host, dependent: :delete
 
       scoped_search relation: :host_reports, on: :change, rename: :report_changes, only_explicit: true
       scoped_search relation: :host_reports, on: :nochange, rename: :report_nochanges, only_explicit: true
       scoped_search relation: :host_reports, on: :failure, rename: :report_failures, only_explicit: true
       scoped_search relation: :host_reports, on: :format, rename: :report_format, only_explicit: true, complete_value: { plain: 0, puppet: 1, ansible: 2 }
+
+      def last_host_report_object
+        host_reports.order("#{HostReport.table_name}.reported_at DESC, #{HostReport.table_name}.id").limit(1)&.first
+      end
+
+      def configuration_status(options = {})
+        @configuration_status ||= get_status(HostStatus::HostReportStatus).to_status(options)
+      end
+
+      def configuration_status_label(options = {})
+        @configuration_status_label ||= get_status(HostStatus::HostReportStatus).to_label(options)
+      end
     end
   end
 end

--- a/app/models/host_status/host_report_status.rb
+++ b/app/models/host_status/host_report_status.rb
@@ -2,7 +2,7 @@ module HostStatus
   # rubocop:disable Style/GuardClause
   class HostReportStatus < Status
     def last_report
-      self.last_report = host.last_host_report_object_any_format unless @last_report_set
+      self.last_report = host.last_host_report_object unless @last_report_set
       @last_report
     end
 

--- a/test/model/host_report_status_test.rb
+++ b/test/model/host_report_status_test.rb
@@ -23,6 +23,30 @@ class HostReportStatusTest < ActiveSupport::TestCase
     assert_nil status.last_report
   end
 
+  test "last_host_report_object returns latest report" do
+    assert_equal report, host.last_host_report_object
+  end
+
+  test "empty configuration status host attribute" do
+    assert_equal 0, host.configuration_status
+  end
+
+  test "empty configuration status host attribute label" do
+    assert_equal "Empty", host.configuration_status_label
+  end
+
+  test "empty configuration status host attribute" do
+    report.failure = 5
+    report.save!
+    assert_equal(-1, host.configuration_status)
+  end
+
+  test "empty configuration status host attribute label" do
+    report.failure = 5
+    report.save!
+    assert_equal "Failure(s)", host.configuration_status_label
+  end
+
   describe "host with no reports" do
     let(:host) { FactoryBot.create(:host) }
 


### PR DESCRIPTION
Oleh is running into issue when you have a host with old configuration status and new plugin is activated, the search query will find the old configuration report (type is ignored for some reason in ActiveRecord), therefore I am creating an additional association that will always filter out only HostReports by type.

I am also droppign the destroy action which was required by Rubocop, this is actually not wanted - we want to ingore this on delete as host reports are destroyed by many to many association above.

This resolves: https://github.com/theforeman/foreman/pull/9145

```
22:42:12 rails.1 | 2022-03-13T22:42:12 [I|app|24c6a649] Backtrace for 'Action failed' error (ActionView::Template::Error): undefined method 'failure' for #ConfigReport:0x00000000120625b8
22:42:12 rails.1 | 24c6a649 | Did you mean? failed
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/.vendor/ruby/2.7.0/gems/activemodel-6.0.3.7/lib/active_model/attribute_methods.rb:432:in 'method_missing'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman_host_reports/app/models/host_status/host_report_status.rb:24:in 'failure'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman_host_reports/app/models/host_status/host_report_status.rb:36:in 'failure?'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman_host_reports/app/models/host_status/host_report_status.rb:109:in 'to_global'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/app/models/host_status/global.rb:20:in 'block in build'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/app/models/host_status/global.rb:20:in 'map'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/app/models/host_status/global.rb:20:in 'build'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/app/models/host/managed.rb:793:in 'global_status_label'
22:42:12 rails.1 | 24c6a649 | /home/vagrant/foreman/app/views/api/v2/hosts/main.json.rabl:8:in 'cached_source_3462173823462388035'
...
22:42:12 rails.1 | 2022-03-13T22:42:12 [I|app|24c6a649] Rendering api/v2/errors/standard_error.json.rabl within api/v2/layouts/error_layout
22:42:12 rails.1 | 2022-03-13T22:42:12 [I|app|24c6a649] Rendered api/v2/errors/standard_error.json.rabl within api/v2/layouts/error_layout (Duration: 1.2ms | Allocations: 299)
22:42:12 rails.1 | 2022-03-13T22:42:12 [I|app|24c6a649] Completed 500 Internal Server Error in 218ms (Views: 3.1ms | ActiveRecord: 33.8ms | Allocations: 36102)
```