### PR TITLE
Add keywords popover and search chips

### DIFF
--- a/webpack/src/components/ReportsTab/KeywordsPopover.js
+++ b/webpack/src/components/ReportsTab/KeywordsPopover.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Popover, Chip, ChipGroup } from '@patternfly/react-core';
+import { TagIcon } from '@patternfly/react-icons';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const KeywordsPopover = ({ keywords, setFilters }) => {
+  const [isVisible, setIsVisible] = React.useState(false);
+  const toggleVisibility = () => setIsVisible(v => !v);
+  let timeoutID;
+  const onMouseLeave = () => {
+    timeoutID = setTimeout(() => {
+      setIsVisible(false);
+    }, 300);
+  };
+
+  const onMouseEnter = () => {
+    if (timeoutID) {
+      clearTimeout(timeoutID);
+    }
+    setIsVisible(true);
+  };
+  return (
+    <Popover
+      aria-label="Popover that shows reports keyords"
+      isVisible={isVisible}
+      shouldOpen={toggleVisibility}
+      shouldClose={toggleVisibility}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      headerContent={<div>{__('Keywords')}</div>}
+      bodyContent={
+        <ChipGroup>
+          {keywords.map(keyword => (
+            <Chip
+              key={keyword}
+              component="button"
+              onClick={() =>
+                setFilters(prev => ({
+                  ...prev,
+                  [keyword]: `keyword = ${keyword}`,
+                }))
+              }
+              isOverflowChip
+            >
+              {keyword}
+            </Chip>
+          ))}
+        </ChipGroup>
+      }
+    >
+      <span onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <TagIcon color={keywords.length ? '#6a6e73' : '#d2d2d2'} />{' '}
+        {keywords.length}
+      </span>
+    </Popover>
+  );
+};
+
+KeywordsPopover.propTypes = {
+  keywords: PropTypes.array,
+  setFilters: PropTypes.func.isRequired,
+};
+
+KeywordsPopover.defaultProps = {
+  keywords: [],
+};
+
+export default KeywordsPopover;

--- a/webpack/src/components/ReportsTab/ReportsTable.js
+++ b/webpack/src/components/ReportsTab/ReportsTable.js
@@ -20,7 +20,7 @@ import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { getColumns } from './helpers';
 
-const ReportsTable = ({ reports, status, fetchReports }) => {
+const ReportsTable = ({ reports, status, fetchReports, setFilters }) => {
   const columns = getColumns(fetchReports);
   let tableBody = null;
   let tableHead = null;
@@ -45,7 +45,7 @@ const ReportsTable = ({ reports, status, fetchReports }) => {
             <Tr key={rowIndex}>
               {columns.map(({ title, formatter }, cellIndex) => (
                 <Td key={`${rowIndex}_${cellIndex}`} dataLabel={title}>
-                  {formatter(row)}
+                  {formatter(row, setFilters)}
                 </Td>
               ))}
             </Tr>
@@ -107,6 +107,7 @@ ReportsTable.propTypes = {
   reports: PropTypes.array,
   status: PropTypes.string,
   fetchReports: PropTypes.func.isRequired,
+  setFilters: PropTypes.func.isRequired,
 };
 
 ReportsTable.defaultProps = {

--- a/webpack/src/components/ReportsTab/SearchBarChips.js
+++ b/webpack/src/components/ReportsTab/SearchBarChips.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+
+const SearchBarChips = ({ filters, setFilters }) => (
+  <ChipGroup>
+    {Object.keys(filters).flatMap(filter =>
+      filters[filter] ? (
+        <Chip
+          key={filter}
+          onClick={() =>
+            setFilters(prev => ({
+              ...prev,
+              [filter]: false,
+            }))
+          }
+        >
+          {filters[filter]}
+        </Chip>
+      ) : (
+        []
+      )
+    )}
+  </ChipGroup>
+);
+
+SearchBarChips.propTypes = {
+  filters: PropTypes.array,
+  setFilters: PropTypes.func.isRequired,
+};
+
+SearchBarChips.defaultProps = {
+  filters: [],
+};
+
+export default SearchBarChips;

--- a/webpack/src/components/ReportsTab/StatusToggleGroup.js
+++ b/webpack/src/components/ReportsTab/StatusToggleGroup.js
@@ -9,8 +9,11 @@ import {
 import { translate as __ } from 'foremanReact/common/I18n';
 
 const StatusToggleGroup = ({ setSelected, selected }) => {
-  const onChange = (isSelected, { currentTarget: { id } }) =>
-    setSelected(prev => ({ ...prev, [id]: isSelected }));
+  const onChange = (isSelected, { currentTarget: { id: statusName } }) =>
+    setSelected(prev => ({
+      ...prev,
+      [statusName]: isSelected ? `${statusName} > 0` : false,
+    }));
 
   return (
     <ToggleGroup aria-label="Icon variant toggle group">

--- a/webpack/src/components/ReportsTab/helpers.js
+++ b/webpack/src/components/ReportsTab/helpers.js
@@ -8,19 +8,18 @@ import {
   KebabToggle,
   FlexItem,
   Flex,
-  Tooltip,
 } from '@patternfly/react-core';
 import {
   ExclamationCircleIcon,
   SyncAltIcon,
   CheckCircleIcon,
   BanIcon,
-  TagIcon,
 } from '@patternfly/react-icons';
 import { openConfirmModal } from 'foremanReact/components/ConfirmModal';
 import { APIActions } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { reportToShowFormatter } from '../../Router/HostReports/IndexPage/Components/HostReportsTable/Components/Formatters';
+import KeywordsPopover from './KeywordsPopover';
 
 const FailedIcon = ({ label, withMargin = false }) => (
   <span style={withMargin ? { marginRight: '15px' } : {}}>
@@ -67,13 +66,8 @@ export const globalStatusFormatter = ({ status }) => {
   }
 };
 
-export const keywordsFormatter = ({ keywords = [] }) => (
-  <>
-    <Tooltip content={<div>{keywords.join(',\n')}</div>}>
-      <TagIcon color={keywords.length ? '#6a6e73' : '#d2d2d2'} />{' '}
-      {keywords.length}
-    </Tooltip>
-  </>
+export const keywordsFormatter = ({ keywords }, setFilters) => (
+  <KeywordsPopover keywords={keywords} setFilters={setFilters} />
 );
 
 export const ActionFormatter = ({ id, can_delete }, fetchReports) => {

--- a/webpack/src/components/ReportsTab/index.js
+++ b/webpack/src/components/ReportsTab/index.js
@@ -16,6 +16,7 @@ import { useForemanSettings } from 'foremanReact/Root/Context/ForemanContext';
 import { HOST_REPORTS_SEARCH_PROPS } from '../../Router/HostReports/IndexPage/constants';
 import ReportsTable from './ReportsTable';
 import StatusToggleGroup from './StatusToggleGroup';
+import SearchBarChips from './SearchBarChips';
 
 const ReportsTab = ({ hostName, format }) => {
   const dispatch = useDispatch();
@@ -78,7 +79,7 @@ const ReportsTab = ({ hostName, format }) => {
 
       Object.keys(_filters).forEach(filter => {
         if (_filters[filter]) {
-          serverQuery.push(`${filter} > 0`);
+          serverQuery.push(_filters[filter]);
         }
       });
 
@@ -115,6 +116,7 @@ const ReportsTab = ({ hostName, format }) => {
           data={HOST_REPORTS_SEARCH_PROPS}
           onSearch={search => fetchReports({ search, page: 1 })}
         />
+        <SearchBarChips filters={filters} setFilters={setFilters} />
       </GridItem>
       <GridItem span={4}>
         <StatusToggleGroup setSelected={setFilters} selected={filters} />
@@ -132,6 +134,7 @@ const ReportsTab = ({ hostName, format }) => {
           reports={reports}
           status={status}
           fetchReports={fetchReports}
+          setFilters={setFilters}
         />
       </GridItem>
       <GridItem>


### PR DESCRIPTION
When hovering a keywords tag, a popover would appear.
When clicking on one of the keywords, the query will be
shown in a chip under the searchbar.


https://user-images.githubusercontent.com/26363699/158600176-be6a4eb4-a7d2-49e1-88c1-8898bbebbe3a.mp4

cc @lzap @ofedoren @marisvirik