### PR TITLE
Use scoped_search for the widgets

### DIFF
--- a/app/helpers/foreman_host_reports/reports_dashboard_helper.rb
+++ b/app/helpers/foreman_host_reports/reports_dashboard_helper.rb
@@ -1,11 +1,12 @@
 module ForemanHostReports
   module ReportsDashboardHelper
-    def host_reports_searchable_links(name, search, counter, format)
+    def host_reports_searchable_links(name, count_method, format)
+      search = Host.send("#{count_method}_query", format, user_search_query)
       content_tag :li, :style => "margin-bottom: 5px" do
-        content_tag(:span, sanitize('&nbsp;'), :class => 'label', :style => "background-color: #{host_reports_report_color[counter]}") +
+        content_tag(:span, sanitize('&nbsp;'), :class => 'label', :style => "background-color: #{host_reports_report_color[count_method]}") +
           sanitize('&nbsp;') +
           link_to(name, hosts_path(:search => search), :class => "dashboard-links") +
-          content_tag(:span, send(counter, format), class: 'pull-right')
+          content_tag(:span, Host.send(count_method, format, user_search_query), class: 'pull-right')
       end
     end
 
@@ -14,33 +15,52 @@ module ForemanHostReports
         :change_hosts => "#4572A7",
         :failure_hosts => "#AA4643",
         :nochange_hosts => "#DB843D",
+        :noevents_hosts => "#89A54E",
+        :outofsync_hosts => "#3D96AE",
+        :noreports_hosts => "#DB843D",
         :disabled_hosts => "#92A8CD",
       }
+    end
+
+    def host_reports_translated_header(shortname, longname)
+      "<th style='width:85px; class='ca'><span class='small' title='' data-original-title='#{longname}'>#{shortname}</span></th>"
     end
 
     def host_reports_get_overview(options = {})
       format = options[:format]
       state_labels = {
-        change_hosts: _('Change'),
-        failure_hosts: _('Failure'),
-        nochange_hosts: _('No Change'),
+        change_hosts: _('Change(s)'),
+        failure_hosts: _('Failure(s)'),
+        nochange_hosts: _('No change(s)'),
+        noevents_hosts: _('No event(s)'),
+        outofsync_hosts: _('Out of sync'),
+        noreports_hosts: _('No reports'),
         disabled_hosts: _('Disabled alerts'),
       }
       counter = {}
       total = 0
       data = state_labels.map do |key, label|
-        counter.store(key, send(key, format))
+        counter.store(key, Host.send(key, format, user_search_query))
         total = counter[key] + total
         [label, counter[key], host_reports_report_color[key]]
       end
+      failed_percent = total.zero? ? 0 : (counter[:failure_hosts].fdiv(total) * 100).round
       {
         data: data,
         searchUrl: hosts_path(search: '~VAL~'),
-        title: { primary: _("#{(counter[:failure_hosts].fdiv(total) * 100).to_i}%"), secondary: state_labels[:failure_hosts] },
+        title: { primary: _("#{failed_percent}%"), secondary: state_labels[:failure_hosts] },
         searchFilters: state_labels.each_with_object({}) do |(key, filter), filters|
           filters[filter] = counter[key]
         end,
       }
+    end
+
+    def user_search_query
+      if @data&.filter&.present?
+        "#{@data&.filter} and "
+      else
+        ""
+      end
     end
 
     def latest_reports
@@ -54,26 +74,8 @@ module ForemanHostReports
       latest_reports.limit(1).present?
     end
 
-    def host_reports_translated_header(shortname, longname)
-      "<th style='width:85px; class='ca'><span class='small' title='' data-original-title='#{longname}'>#{shortname}</span></th>"
-    end
-
-    private
-
-    def disabled_hosts(_format = nil)
-      Host.authorized(:view_hosts, Host).where(:enabled => false).count
-    end
-
-    def change_hosts(format)
-      HostReport.authorized(:view_host_reports).my_reports.where("format = ? and change > 0", HostReport.formats[format]).reorder('').group(:host_id).maximum(:id).count
-    end
-
-    def nochange_hosts(format)
-      HostReport.authorized(:view_host_reports).my_reports.where("format = ? and nochange > 0", HostReport.formats[format]).reorder('').group(:host_id).maximum(:id).count
-    end
-
-    def failure_hosts(format)
-      HostReport.authorized(:view_host_reports).my_reports.where("format = ? and failure > 0", HostReport.formats[format]).reorder('').group(:host_id).maximum(:id).count
+    def total_hosts(format)
+      Host.search_for(user_search_query + "report_format = #{format}").reorder("").count
     end
   end
 end

--- a/app/models/concerns/foreman_host_reports/host_extensions.rb
+++ b/app/models/concerns/foreman_host_reports/host_extensions.rb
@@ -12,7 +12,7 @@ module ForemanHostReports
       scoped_search relation: :host_reports, on: :format, rename: :report_format, only_explicit: true, complete_value: { plain: 0, puppet: 1, ansible: 2 }
 
       def last_host_report_object
-        host_reports.order("#{HostReport.table_name}.reported_at DESC, #{HostReport.table_name}.id").limit(1)&.first
+        host_reports.reorder("#{HostReport.table_name}.id DESC").limit(1)&.first
       end
 
       def configuration_status(options = {})
@@ -21,6 +21,74 @@ module ForemanHostReports
 
       def configuration_status_label(options = {})
         @configuration_status_label ||= get_status(HostStatus::HostReportStatus).to_label(options)
+      end
+    end
+
+    class_methods do
+      def interval_query(format)
+        interval_setting = (Setting[:"#{format}_interval"] || Setting[:outofsync_interval]).to_i
+        "\"#{interval_setting} minutes ago\""
+      end
+
+      def failure_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and " \
+          "report_failures > 0 and last_report > #{interval_query(format)} and status.enabled = true"
+      end
+
+      def failure_hosts(format, prefix = '')
+        Host.search_for(failure_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def change_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and " \
+          "report_failures = 0 and report_changes > 0 and last_report > #{interval_query(format)} and status.enabled = true"
+      end
+
+      def change_hosts(format, prefix = '')
+        Host.search_for(change_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def nochange_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and " \
+          "report_failures = 0 and report_changes = 0 and report_nochanges > 0 and last_report > #{interval_query(format)} and status.enabled = true"
+      end
+
+      def nochange_hosts(format, prefix = '')
+        Host.search_for(nochange_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def noevents_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and " \
+          "report_failures = 0 and report_changes = 0 and report_nochanges = 0 and last_report > #{interval_query(format)} and status.enabled = true"
+      end
+
+      def noevents_hosts(format, prefix = '')
+        Host.search_for(noevents_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def noreports_hosts_query(_format, prefix = '')
+        # always across all formats because there are no reports (thus format is unknown)
+        "#{prefix}null? last_report"
+      end
+
+      def noreports_hosts(format, prefix = '')
+        Host.search_for(noreports_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def outofsync_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and last_report <= #{interval_query(format)} and status.enabled = true"
+      end
+
+      def outofsync_hosts(format, prefix = '')
+        Host.search_for(outofsync_hosts_query(format, prefix)).reorder("").count
+      end
+
+      def disabled_hosts_query(format, prefix = '')
+        prefix + "report_format = #{format} and status.enabled = false"
+      end
+
+      def disabled_hosts(format, prefix = '')
+        Host.search_for(disabled_hosts_query(format, prefix)).reorder("").count
       end
     end
   end

--- a/app/views/dashboard/_host_reports_status_chart_widget.html.erb
+++ b/app/views/dashboard/_host_reports_status_chart_widget.html.erb
@@ -3,9 +3,9 @@
 %>
 <h4 class="header">
   <% if format %>
-    <%= _('%s Host Reports Chart') % format %>
+    <%= _('Latest %s Host Reports Chart') % format %>
   <% else %>
-    <%= _('All Host Reports Chart') %>
+    <%= _('Latest Host Reports Chart') %>
   <% end %>
 </h4>
 <div class="host-configuration-chart">

--- a/app/views/dashboard/_host_reports_status_links.html.erb
+++ b/app/views/dashboard/_host_reports_status_links.html.erb
@@ -1,5 +1,7 @@
-
-<%= host_reports_searchable_links _('Hosts with changes'), "report_changes > 0 and report_format = #{format}", :change_hosts, format%>
-<%= host_reports_searchable_links _('Hosts without changes'), "report_nochanges > 0 and report_format = #{format}", :nochange_hosts, format %>
-<%= host_reports_searchable_links _('Hosts with failures'), "report_failures > 0 and report_format =  #{format}" , :failure_hosts, format %>
-<%= host_reports_searchable_links _('Hosts with disabled alerts'), "status.enabled = false" , :disabled_hosts, format %>
+<%= host_reports_searchable_links _('Hosts with failures'), :failure_hosts, format %>
+<%= host_reports_searchable_links _('Hosts with changes'), :change_hosts, format %>
+<%= host_reports_searchable_links _('Hosts without changes'), :nochange_hosts, format %>
+<%= host_reports_searchable_links _('Hosts without events'), :noevents_hosts, format %>
+<%= host_reports_searchable_links _('Out of sync hosts'), :outofsync_hosts, format %>
+<%= host_reports_searchable_links _('Hosts with alerts disabled'), :disabled_hosts, format %>
+<%= host_reports_searchable_links _('Hosts with no reports across formats'), :noreports_hosts, format %>

--- a/app/views/dashboard/_host_reports_status_widget.html.erb
+++ b/app/views/dashboard/_host_reports_status_widget.html.erb
@@ -1,11 +1,11 @@
 <h4 class="header">
   <% if (format = settings[:format]) %>
-    <%= _('%s Host Reports') % settings[:format] %>
+    <%= _('Latest %s Host Reports') % settings[:format] %>
   <% else %>
-    <%= _('All Host Reports %s') % disabled_hosts%>
+    <%= _('Latest Host Reports %s') % disabled_hosts%>
   <% end %>
 </h4>
 <ul>
-  <%= render "dashboard/host_reports_status_links", format: format.downcase %>
-  <h4 class="total"><%= _("Total Hosts: %s") % Host.all.count %></h4>
+  <%= render "dashboard/host_reports_status_links", format: format&.downcase %>
+  <h4 class="total"><%= _("Total hosts: %s") % total_hosts(format&.downcase) %></h4>
 </ul>

--- a/lib/foreman_host_reports/engine.rb
+++ b/lib/foreman_host_reports/engine.rb
@@ -49,8 +49,8 @@ module ForemanHostReports
         in_to_prepare do
           HostReport.formats.each do |format, _|
             if format != 'plain' && (format = format.capitalize)
-              widget 'host_reports_status_chart_widget', :name => N_(" %s Host Reports Chart ") % format, :sizex => 4, :sizey => 1, settings: { format: format }
-              widget 'host_reports_status_widget', :name => N_(" %s Host Reports ") % format, :sizex => 4, :sizey => 1, settings: { format: format }
+              widget 'host_reports_status_chart_widget', :name => N_("Latest %s Host Reports Chart ") % format, :sizex => 4, :sizey => 1, settings: { format: format }
+              widget 'host_reports_status_widget', :name => N_("Latest %s Host Reports ") % format, :sizex => 4, :sizey => 1, settings: { format: format }
             end
           end
 

--- a/test/factories/foreman_host_reports_factories.rb
+++ b/test/factories/foreman_host_reports_factories.rb
@@ -2,11 +2,29 @@ FactoryBot.define do
   factory :host_report do
     host
     sequence(:proxy) { |n| FactoryBot.create(:smart_proxy, url: "http://proxy#{n}.example.com", features: [FactoryBot.create(:feature, name: 'Reports')]) }
-    reported_at { Time.now.utc }
+    reported_at { DateTime.now }
     change { 0 }
     nochange { 0 }
     failure { 0 }
     body { '{}' }
+  end
+
+  trait :recent do
+    after(:build) do |report, _evaluator|
+      report.host = FactoryBot.create(:host, last_report: DateTime.now)
+    end
+  end
+
+  trait :outofsync do
+    reported_at { DateTime.now - 99.days }
+    after(:build) do |report, _evaluator|
+      report.host = FactoryBot.create(:host, last_report: DateTime.now - 99.days)
+    end
+  end
+
+  trait :empty do
+    reported_at { DateTime.now - 99.days }
+    host
   end
 
   trait :puppet_format do

--- a/test/unit/dashboard_test.rb
+++ b/test/unit/dashboard_test.rb
@@ -3,63 +3,43 @@ require 'test_plugin_helper'
 class DashboardTest < ActiveSupport::TestCase
   include ForemanHostReports::ReportsDashboardHelper
 
-  let(:ansible_report_with_change) { FactoryBot.create(:host_report, :ansible_format, :with_change) }
-  let(:ansible_report_with_nochange) { FactoryBot.create(:host_report, :ansible_format, :with_nochange) }
-  let(:ansible_report_with_failure) { FactoryBot.create(:host_report, :ansible_format, :with_failure) }
-
-  let(:puppet_report_with_change) { FactoryBot.create(:host_report, :puppet_format, :with_change) }
-  let(:puppet_report_with_nochange) { FactoryBot.create(:host_report, :puppet_format, :with_nochange) }
-  let(:puppet_report_with_failure) { FactoryBot.create(:host_report, :puppet_format, :with_failure) }
-
-  let(:puppet_format) { puppet_report_with_nochange.format }
-  let(:ansible_format) { ansible_report_with_change.format }
-
-  let(:host1) { ansible_report_with_change.host }
-  let(:host2) { puppet_report_with_nochange.host }
-  let(:host3) { puppet_report_with_failure.host }
-  let(:hosts) { [host1, host2, host3] }
-
-  test 'check number of host reports with changes and ansible format' do
-    changed = ansible_report_with_change.change + ansible_report_with_nochange.change + ansible_report_with_failure.change
-    assert_equal change_hosts(ansible_format), changed
-  end
-
-  test 'check number of host reports with changes and puppet format' do
-    changed = puppet_report_with_change.change + puppet_report_with_nochange.change + puppet_report_with_failure.change
-    assert_equal change_hosts(puppet_format), changed
-  end
-
-  test 'check number of host reports with no changes and ansible format' do
-    nochange = ansible_report_with_change.nochange + ansible_report_with_nochange.nochange + ansible_report_with_failure.nochange
-    assert_equal nochange_hosts(ansible_format), nochange
-  end
-
-  test 'check number of host reports with no changes and puppet format' do
-    nochange = puppet_report_with_change.nochange + puppet_report_with_nochange.nochange + puppet_report_with_failure.nochange
-    assert_equal nochange_hosts(puppet_format), nochange
-  end
-
-  test 'check number of host reports with failures and ansible format' do
-    failure = ansible_report_with_change.failure + ansible_report_with_nochange.failure + ansible_report_with_failure.failure
-    assert_equal failure_hosts(ansible_format), failure
-  end
-
-  test 'check number of host reports with failures and puppet format' do
-    failure = puppet_report_with_change.failure + puppet_report_with_nochange.failure + puppet_report_with_failure.failure
-    assert_equal failure_hosts(puppet_format), failure
-  end
-
-  test 'check Hosts with disabled alerts ' do
-    host1.update(:enabled => false)
-    disabled = hosts.reject(&:enabled?)
-    assert_equal disabled_hosts, disabled.count
-  end
-
   test 'latest_reports' do
     FactoryBot.create(:host_report, :ansible_format, :with_change)
     FactoryBot.create(:host_report, :ansible_format, :with_nochange)
     as_admin do
       assert_equal latest_reports.count, 2
+    end
+  end
+
+  %w[puppet ansible].each do |format|
+    test "no events #{format} host" do
+      FactoryBot.create(:host_report, :recent, format: format)
+      assert_equal 1, Host.noevents_hosts(format)
+    end
+
+    test "empty #{format} host" do
+      FactoryBot.create(:host_report, :recent, :empty, format: format)
+      assert_equal 1, Host.noreports_hosts(format)
+    end
+
+    test "out of sync #{format} host" do
+      FactoryBot.create(:host_report, :outofsync, format: format)
+      assert_equal 1, Host.outofsync_hosts(format)
+    end
+
+    test "failed #{format} host" do
+      FactoryBot.create(:host_report, :recent, :with_failure, format: format)
+      assert_equal 1, Host.failure_hosts(format)
+    end
+
+    test "change #{format} host" do
+      FactoryBot.create(:host_report, :recent, :with_change, format: format)
+      assert_equal 1, Host.change_hosts(format)
+    end
+
+    test "nochange #{format} host" do
+      FactoryBot.create(:host_report, :recent, :with_nochange, format: format)
+      assert_equal 1, Host.nochange_hosts(format)
     end
   end
 end


### PR DESCRIPTION
Solves several problems with our widgets - mixing ActiveRecord with scoped_search was not a good idea which I came up with.

To test, I recommend to delete all hosts (thus reports) and then create various variations:

```
HostReport.create!(host: Host.create(name: "r011"), body: "", reported_at: Time.now.utc, format: 1, failure: 0, change: 1, nochange: 1)
Host.update_all(last_report: Time.now)
```